### PR TITLE
Alphabet modification

### DIFF
--- a/src/HasHashSlug.php
+++ b/src/HasHashSlug.php
@@ -58,7 +58,7 @@ trait HasHashSlug {
 			if(isset(static::$alphabet)) {
 				$alphabet = static::$alphabet;
 			}else{
-				$alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+				$alphabet = 'bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ1234567890';
 			}
 
 			$salt = config('hashslug.appsalt', env('APP_KEY')) . $modelSalt;


### PR DESCRIPTION
With the removing of the following letters:  'a', 'e', 'i', 'o', 'u' as well as upper case ones we prevent the generator to accidentally create a slug with some curse/pervert/swear parts.

Could add to the alphabet characters as: '_', '-' to make the "pool of choice" bigger since 10 characters are now missing.

But still, number 3 can replace 'E', 4 can replace 'A', 0 can replace 'O' so still a little danger remains 😄 